### PR TITLE
Add support for more base encodings

### DIFF
--- a/multibase.go
+++ b/multibase.go
@@ -2,9 +2,11 @@ package multibase
 
 import (
 	"encoding/hex"
+	"encoding/base64"
 	"fmt"
 
 	b58 "github.com/jbenet/go-base58"
+	b32 "github.com/whyrusleeping/base32"
 )
 
 const (
@@ -12,19 +14,33 @@ const (
 	Base2        = '0'
 	Base8        = '7'
 	Base10       = '9'
-	Base16       = 'f'
+	Base16       = 'f' // 'F'
+	Base32       = 'u' // 'U'
+	Base32hex    = 'v' // 'V'
 	Base58Flickr = 'Z'
 	Base58BTC    = 'z'
+	Base64       = 'y'
+	Base64url    = 'Y'
 )
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
 
 func Encode(base int, data []byte) (string, error) {
 	switch base {
+	case Base16, 'F':
+		return string(Base16) + hex.EncodeToString(data), nil
+	case Base32, 'U':
+		return string(Base32) + b32.RawStdEncoding.EncodeToString(data), nil
+	case Base32hex, 'V':
+		return string(Base32hex) + b32.RawHexEncoding.EncodeToString(data), nil
 	case Base58BTC:
 		return string(Base58BTC) + b58.EncodeAlphabet(data, b58.BTCAlphabet), nil
-	case Base16:
-		return string(Base16) + hex.EncodeToString(data), nil
+	case Base58Flickr:
+		return string(Base58Flickr) + b58.EncodeAlphabet(data, b58.FlickrAlphabet), nil
+	case Base64:
+		return string(Base64) + base64.StdEncoding.EncodeToString(data), nil
+	case Base64url:
+		return string(Base64url) + base64.URLEncoding.EncodeToString(data), nil
 	default:
 		return "", ErrUnsupportedEncoding
 	}
@@ -36,9 +52,27 @@ func Decode(data string) (int, []byte, error) {
 	}
 
 	switch data[0] {
+	case Base16, 'F':
+		bytes, err := hex.DecodeString(data[1:])
+		return Base16, bytes, err
+	case Base32, 'U':
+		bytes, err := b32.RawStdEncoding.DecodeString(data[1:])
+		return Base32, bytes, err
+	case Base32hex, 'V':
+		bytes, err := b32.RawHexEncoding.DecodeString(data[1:])
+		return Base32hex, bytes, err
 	case Base58BTC:
 		return Base58BTC, b58.DecodeAlphabet(data[1:], b58.BTCAlphabet), nil
+	case Base58Flickr:
+		return Base58Flickr, b58.DecodeAlphabet(data[1:], b58.FlickrAlphabet), nil
+	case Base64:
+		bytes, err := base64.StdEncoding.DecodeString(data[1:])
+		return Base64, bytes, err
+	case Base64url:
+		bytes, err := base64.URLEncoding.DecodeString(data[1:])
+		return Base64url, bytes, err
 	default:
 		return -1, nil, ErrUnsupportedEncoding
 	}
 }
+

--- a/multibase.go
+++ b/multibase.go
@@ -10,37 +10,50 @@ import (
 )
 
 const (
-	Base1        = '1'
-	Base2        = '0'
-	Base8        = '7'
-	Base10       = '9'
-	Base16       = 'f' // 'F'
-	Base32       = 'u' // 'U'
-	Base32hex    = 'v' // 'V'
-	Base58Flickr = 'Z'
-	Base58BTC    = 'z'
-	Base64       = 'y'
-	Base64url    = 'Y'
+	Base1             = '1'
+	Base2             = '0'
+	Base8             = '7'
+	Base10            = '9'
+	Base16            = 'f'
+	Base16Upper       = 'F'
+	Base32            = 'b'
+	Base32Upper       = 'B'
+	Base32pad         = 'c'
+	Base32padUpper    = 'C'
+	Base32hex         = 'v'
+	Base32hexUpper    = 'V'
+	Base32hexPad      = 't'
+	Base32hexPadUpper = 'T'
+	Base58Flickr      = 'Z'
+	Base58BTC         = 'z'
+	Base64            = 'm'
+	Base64url         = 'u'
+	Base64pad         = 'M'
+	Base64urlPad      = 'U'
 )
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
 
 func Encode(base int, data []byte) (string, error) {
 	switch base {
-	case Base16, 'F':
+	case Base16, Base16Upper:
 		return string(Base16) + hex.EncodeToString(data), nil
-	case Base32, 'U':
+	case Base32, Base32Upper:
 		return string(Base32) + b32.RawStdEncoding.EncodeToString(data), nil
-	case Base32hex, 'V':
+	case Base32hex, Base32hexUpper:
 		return string(Base32hex) + b32.RawHexEncoding.EncodeToString(data), nil
+	case Base32pad, Base32padUpper:
+		return string(Base32pad) + b32.StdEncoding.EncodeToString(data), nil
+	case Base32hexPad, Base32hexPadUpper:
+		return string(Base32hexPad) + b32.HexEncoding.EncodeToString(data), nil
 	case Base58BTC:
 		return string(Base58BTC) + b58.EncodeAlphabet(data, b58.BTCAlphabet), nil
 	case Base58Flickr:
 		return string(Base58Flickr) + b58.EncodeAlphabet(data, b58.FlickrAlphabet), nil
-	case Base64:
-		return string(Base64) + base64.StdEncoding.EncodeToString(data), nil
-	case Base64url:
-		return string(Base64url) + base64.URLEncoding.EncodeToString(data), nil
+	case Base64pad:
+		return string(Base64pad) + base64.StdEncoding.EncodeToString(data), nil
+	case Base64urlPad:
+		return string(Base64urlPad) + base64.URLEncoding.EncodeToString(data), nil
 	default:
 		return "", ErrUnsupportedEncoding
 	}
@@ -52,25 +65,31 @@ func Decode(data string) (int, []byte, error) {
 	}
 
 	switch data[0] {
-	case Base16, 'F':
+	case Base16, Base16Upper:
 		bytes, err := hex.DecodeString(data[1:])
 		return Base16, bytes, err
-	case Base32, 'U':
+	case Base32, Base32Upper:
 		bytes, err := b32.RawStdEncoding.DecodeString(data[1:])
 		return Base32, bytes, err
-	case Base32hex, 'V':
+	case Base32hex, Base32hexUpper:
 		bytes, err := b32.RawHexEncoding.DecodeString(data[1:])
 		return Base32hex, bytes, err
+	case Base32pad, Base32padUpper:
+		bytes, err := b32.StdEncoding.DecodeString(data[1:])
+		return Base32pad, bytes, err
+	case Base32hexPad, Base32hexPadUpper:
+		bytes, err := b32.HexEncoding.DecodeString(data[1:])
+		return Base32hexPad, bytes, err
 	case Base58BTC:
 		return Base58BTC, b58.DecodeAlphabet(data[1:], b58.BTCAlphabet), nil
 	case Base58Flickr:
 		return Base58Flickr, b58.DecodeAlphabet(data[1:], b58.FlickrAlphabet), nil
-	case Base64:
+	case Base64pad:
 		bytes, err := base64.StdEncoding.DecodeString(data[1:])
-		return Base64, bytes, err
-	case Base64url:
+		return Base64pad, bytes, err
+	case Base64urlPad:
 		bytes, err := base64.URLEncoding.DecodeString(data[1:])
-		return Base64url, bytes, err
+		return Base64urlPad, bytes, err
 	default:
 		return -1, nil, ErrUnsupportedEncoding
 	}

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -10,7 +10,7 @@ func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 16)
 	rand.Read(buf)
 
-	baseList := []int{ Base16, Base32, Base32hex, Base58BTC, Base58Flickr, Base64, Base64url }
+	baseList := []int{ Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad }
 
 	for _, base := range baseList {
 		enc, err := Encode(base, buf)

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -6,29 +6,33 @@ import (
 	"testing"
 )
 
-func TestBase58RoundTrip(t *testing.T) {
+func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 16)
 	rand.Read(buf)
 
-	enc, err := Encode(Base58BTC, buf)
-	if err != nil {
-		t.Fatal(err)
+	baseList := []int{ Base16, Base32, Base32hex, Base58BTC, Base58Flickr, Base64, Base64url }
+
+	for _, base := range baseList {
+		enc, err := Encode(base, buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		e, out, err := Decode(enc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if e != base {
+			t.Fatal("got wrong encoding out")
+		}
+
+		if !bytes.Equal(buf, out) {
+			t.Fatal("input wasnt the same as output", buf, out)
+		}
 	}
 
-	e, out, err := Decode(enc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if e != Base58BTC {
-		t.Fatal("got wrong encoding out")
-	}
-
-	if !bytes.Equal(buf, out) {
-		t.Fatal("input wasnt the same as output", buf, out)
-	}
-
-	_, _, err = Decode("")
+	_, _, err := Decode("")
 	if err == nil {
 		t.Fatal("shouldnt be able to decode empty string")
 	}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
+      "hash": "Qmb1DA2A9LS2wR4FFweB4uEDomFsdmnw1VLawLE1yQzudj",
+      "name": "base32",
+      "version": "0.0.0"
+    },
+    {
+      "author": "whyrusleeping",
       "hash": "QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf",
       "name": "go-base58",
       "version": "0.0.0"


### PR DESCRIPTION
I haven't implemented unary, binary, octal and decimal, but everything else works.
Certain encodings, like base 16 and base 32 have two identifying characters, currently my solution is ugly, but works. I'm open to suggestions.
Also, I'm not sure whether I did gx right, I copypasted the entry for whyrusleeping/base32 from go-ipfs.