### PR TITLE
Added identity encoding as an option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *.swp
-
+/coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+os:
+  - linux
+  - osx
+
+go:
+  - 1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: go
 
 os:
   - linux
-  - osx
 
 go:
   - 1.7
+
+script:
+  - go vet
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/assert.go
+++ b/assert.go
@@ -1,0 +1,32 @@
+package multibase
+
+import (
+	"reflect"
+	"fmt"
+	"testing"
+)
+
+func areEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	return reflect.DeepEqual(expected, actual)
+}
+
+func toMessage(def string, msgAndArgs ...interface{}) string {
+	switch {
+	case msgAndArgs == nil || len(msgAndArgs) == 0:
+		return def
+	case len(msgAndArgs) == 1:
+		return msgAndArgs[0].(string)
+	default:
+		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+	}
+}
+
+func assertEqual(t *testing.T, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if !areEqual(expected, actual) {
+		t.Errorf("%s: \nexpected: %#v\nreceived: %#v\n", toMessage("Not equal", msgAndArgs...), expected, actual)
+	}
+}

--- a/assert.go
+++ b/assert.go
@@ -1,8 +1,8 @@
 package multibase
 
 import (
-	"reflect"
 	"fmt"
+	"reflect"
 	"testing"
 )
 

--- a/multibase.go
+++ b/multibase.go
@@ -21,7 +21,7 @@ const (
 	Base58BTC    = 'z'
 	Base64       = 'y'
 	Base64url    = 'Y'
-	Binary       = 'b' // 'B'
+	Binary       = 'X'
 )
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
@@ -42,7 +42,7 @@ func Encode(base int, data []byte) (string, error) {
 		return string(Base64) + base64.StdEncoding.EncodeToString(data), nil
 	case Base64url:
 		return string(Base64url) + base64.URLEncoding.EncodeToString(data), nil
-	case Binary, 'B':
+	case Binary:
 		return string(Binary) + string(data), nil
 	default:
 		return "", ErrUnsupportedEncoding
@@ -74,7 +74,7 @@ func Decode(data string) (int, []byte, error) {
 	case Base64url:
 		bytes, err := base64.URLEncoding.DecodeString(data[1:])
 		return Base64url, bytes, err
-	case Binary, 'B':
+	case Binary:
 		return Binary, []byte(data[1:]), nil
 	default:
 		return -1, nil, ErrUnsupportedEncoding

--- a/multibase.go
+++ b/multibase.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	Identity          = 0x00
 	Base1             = '1'
 	Base2             = '0'
 	Base8             = '7'
@@ -30,13 +31,14 @@ const (
 	Base64url         = 'u'
 	Base64pad         = 'M'
 	Base64urlPad      = 'U'
-	Binary       = 'X'
 )
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
 
 func Encode(base int, data []byte) (string, error) {
 	switch base {
+	case Identity:
+		return string(Identity) + string(data), nil
 	case Base16, Base16Upper:
 		return string(Base16) + hex.EncodeToString(data), nil
 	case Base32, Base32Upper:
@@ -55,8 +57,6 @@ func Encode(base int, data []byte) (string, error) {
 		return string(Base64pad) + base64.StdEncoding.EncodeToString(data), nil
 	case Base64urlPad:
 		return string(Base64urlPad) + base64.URLEncoding.EncodeToString(data), nil
-	case Binary:
-		return string(Binary) + string(data), nil
 	default:
 		return "", ErrUnsupportedEncoding
 	}
@@ -68,6 +68,8 @@ func Decode(data string) (int, []byte, error) {
 	}
 
 	switch data[0] {
+	case Identity:
+		return Identity, []byte(data[1:]), nil
 	case Base16, Base16Upper:
 		bytes, err := hex.DecodeString(data[1:])
 		return Base16, bytes, err
@@ -93,8 +95,6 @@ func Decode(data string) (int, []byte, error) {
 	case Base64urlPad:
 		bytes, err := base64.URLEncoding.DecodeString(data[1:])
 		return Base64urlPad, bytes, err
-	case Binary:
-		return Binary, []byte(data[1:]), nil
 	default:
 		return -1, nil, ErrUnsupportedEncoding
 	}

--- a/multibase.go
+++ b/multibase.go
@@ -38,6 +38,7 @@ var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
 func Encode(base int, data []byte) (string, error) {
 	switch base {
 	case Identity:
+		// 0x00 inside a string is OK in golang and causes no problems with the length calculation.
 		return string(Identity) + string(data), nil
 	case Base16, Base16Upper:
 		return string(Base16) + hex.EncodeToString(data), nil

--- a/multibase.go
+++ b/multibase.go
@@ -1,8 +1,8 @@
 package multibase
 
 import (
-	"encoding/hex"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	b58 "github.com/jbenet/go-base58"

--- a/multibase.go
+++ b/multibase.go
@@ -2,9 +2,11 @@ package multibase
 
 import (
 	"encoding/hex"
+	"encoding/base64"
 	"fmt"
 
 	b58 "github.com/jbenet/go-base58"
+	b32 "github.com/whyrusleeping/base32"
 )
 
 const (
@@ -12,19 +14,33 @@ const (
 	Base2        = '0'
 	Base8        = '7'
 	Base10       = '9'
-	Base16       = 'f'
+	Base16       = 'f' // 'F'
+	Base32       = 'u' // 'U'
+	Base32hex    = 'v' // 'V'
 	Base58Flickr = 'Z'
 	Base58BTC    = 'z'
+	Base64       = 'y'
+	Base64url    = 'Y'
 )
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
 
 func Encode(base int, data []byte) (string, error) {
 	switch base {
+	case Base16, 'F':
+		return string(Base16) + hex.EncodeToString(data), nil
+	case Base32, 'U':
+		return string(Base32) + b32.RawStdEncoding.EncodeToString(data), nil
+	case Base32hex, 'V':
+		return string(Base32hex) + b32.RawHexEncoding.EncodeToString(data), nil
 	case Base58BTC:
 		return string(Base58BTC) + b58.EncodeAlphabet(data, b58.BTCAlphabet), nil
-	case Base16:
-		return string(Base16) + hex.EncodeToString(data), nil
+	case Base58Flickr:
+		return string(Base58Flickr) + b58.EncodeAlphabet(data, b58.FlickrAlphabet), nil
+	case Base64:
+		return string(Base64) + base64.StdEncoding.EncodeToString(data), nil
+	case Base64url:
+		return string(Base64url) + base64.URLEncoding.EncodeToString(data), nil
 	default:
 		return "", ErrUnsupportedEncoding
 	}
@@ -36,9 +52,27 @@ func Decode(data string) (int, []byte, error) {
 	}
 
 	switch data[0] {
+	case Base16, 'F':
+		bytes, err := hex.DecodeString(data[1:])
+		return Base16, bytes, err
+	case Base32, 'U':
+		bytes, err := b32.RawStdEncoding.DecodeString(data[1:])
+		return Base32, bytes, err
+	case Base32hex, 'V':
+		bytes, err := b32.RawHexEncoding.DecodeString(data[1:])
+		return Base32hex, bytes, err
 	case Base58BTC:
 		return Base58BTC, b58.DecodeAlphabet(data[1:], b58.BTCAlphabet), nil
+	case Base58Flickr:
+		return Base58Flickr, b58.DecodeAlphabet(data[1:], b58.FlickrAlphabet), nil
+	case Base64:
+		bytes, err := base64.StdEncoding.DecodeString(data[1:])
+		return Base64, bytes, err
+	case Base64url:
+		bytes, err := base64.URLEncoding.DecodeString(data[1:])
+		return Base64url, bytes, err
 	default:
 		return -1, nil, ErrUnsupportedEncoding
 	}
 }
+

--- a/multibase.go
+++ b/multibase.go
@@ -21,6 +21,7 @@ const (
 	Base58BTC    = 'z'
 	Base64       = 'y'
 	Base64url    = 'Y'
+	Binary       = 'b' // 'B'
 )
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
@@ -41,6 +42,8 @@ func Encode(base int, data []byte) (string, error) {
 		return string(Base64) + base64.StdEncoding.EncodeToString(data), nil
 	case Base64url:
 		return string(Base64url) + base64.URLEncoding.EncodeToString(data), nil
+	case Binary, 'B':
+		return string(Binary) + string(data), nil
 	default:
 		return "", ErrUnsupportedEncoding
 	}
@@ -71,8 +74,9 @@ func Decode(data string) (int, []byte, error) {
 	case Base64url:
 		bytes, err := base64.URLEncoding.DecodeString(data[1:])
 		return Base64url, bytes, err
+	case Binary, 'B':
+		return Binary, []byte(data[1:]), nil
 	default:
 		return -1, nil, ErrUnsupportedEncoding
 	}
 }
-

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"math/rand"
 	"testing"
-	"fmt"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var sampleBytes = []byte("Decentralize everything!!")
@@ -21,7 +18,7 @@ func testEncode(t *testing.T, encoding int, bytes []byte, expected string)  {
 		t.Error(err)
 		return
 	}
-	assert.Equal(t, expected, actual, fmt.Sprintf("Encoding failure for encoding %c (%d)", encoding, encoding))
+	assertEqual(t, expected, actual, "Encoding failure for encoding %c (%d)", encoding, encoding)
 }
 
 func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data string)  {
@@ -30,8 +27,8 @@ func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data s
 		t.Error(err)
 		return
 	}
-	assert.Equal(t, expectedEncoding, actualEncoding)
-	assert.Equal(t, expectedBytes, actualBytes, fmt.Sprintf("Encoding failure for encoding %c (%d)", expectedEncoding, expectedEncoding))
+	assertEqual(t, expectedEncoding, actualEncoding)
+	assertEqual(t, expectedBytes, actualBytes, "Encoding failure for encoding %c (%d)", expectedEncoding, expectedEncoding)
 }
 
 func TestEncode(t *testing.T)  {

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -8,15 +8,14 @@ import (
 
 var sampleBytes = []byte("Decentralize everything!!")
 var encodedSamples = map[int]string{
-	Identity: string(0x00) + "Decentralize everything!!",
-	Base16: "f446563656e7472616c697a652065766572797468696e672121",
-	//Base16Upper: "F446563656E7472616C697A652065766572797468696E672121",
-	//Base32: "birswgzloorzgc3djpjssazlwmvzhs5dinfxgoijb",
-	//Base32Upper: "BIRSWGZLOORZGC3DJPJSSAZLWMVZHS5DINFXGOIJB",
-	Base64pad: "MRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ==",
+	Identity:     string(0x00) + "Decentralize everything!!",
+	Base16:       "f446563656e7472616c697a652065766572797468696e672121",
+	Base58BTC:    "zUXE7GvtEk8XTXs1GF8HSGbVA9FCX9SEBPe",
+	Base64pad:    "MRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ==",
+	Base64urlPad: "URGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ==",
 }
 
-func testEncode(t *testing.T, encoding int, bytes []byte, expected string)  {
+func testEncode(t *testing.T, encoding int, bytes []byte, expected string) {
 	actual, err := Encode(encoding, bytes)
 	if err != nil {
 		t.Error(err)
@@ -25,7 +24,7 @@ func testEncode(t *testing.T, encoding int, bytes []byte, expected string)  {
 	assertEqual(t, expected, actual, "Encoding failure for encoding %c (%d)", encoding, encoding)
 }
 
-func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data string)  {
+func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data string) {
 	actualEncoding, actualBytes, err := Decode(data)
 	if err != nil {
 		t.Error(err)
@@ -35,13 +34,13 @@ func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data s
 	assertEqual(t, expectedBytes, actualBytes, "Decoding failure for encoding %c (%d)", expectedEncoding, expectedEncoding)
 }
 
-func TestEncode(t *testing.T)  {
+func TestEncode(t *testing.T) {
 	for encoding, data := range encodedSamples {
 		testEncode(t, encoding, sampleBytes, data)
 	}
 }
 
-func TestDecode(t *testing.T)  {
+func TestDecode(t *testing.T) {
 	for encoding, data := range encodedSamples {
 		testDecode(t, encoding, sampleBytes, data)
 	}
@@ -51,7 +50,7 @@ func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 17)
 	rand.Read(buf)
 
-	baseList := []int{ Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad, Identity }
+	baseList := []int{Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad, Identity}
 
 	for _, base := range baseList {
 		enc, err := Encode(base, buf)

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -10,7 +10,7 @@ func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 17)
 	rand.Read(buf)
 
-	baseList := []int{ Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad, Binary }
+	baseList := []int{ Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad, Identity }
 
 	for _, base := range baseList {
 		enc, err := Encode(base, buf)

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -9,6 +9,10 @@ import (
 var sampleBytes = []byte("Decentralize everything!!")
 var encodedSamples = map[int]string{
 	Identity: string(0x00) + "Decentralize everything!!",
+	Base16: "f446563656e7472616c697a652065766572797468696e672121",
+	//Base16Upper: "F446563656E7472616C697A652065766572797468696E672121",
+	//Base32: "birswgzloorzgc3djpjssazlwmvzhs5dinfxgoijb",
+	//Base32Upper: "BIRSWGZLOORZGC3DJPJSSAZLWMVZHS5DINFXGOIJB",
 	Base64pad: "MRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ==",
 }
 
@@ -28,7 +32,7 @@ func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data s
 		return
 	}
 	assertEqual(t, expectedEncoding, actualEncoding)
-	assertEqual(t, expectedBytes, actualBytes, "Encoding failure for encoding %c (%d)", expectedEncoding, expectedEncoding)
+	assertEqual(t, expectedBytes, actualBytes, "Decoding failure for encoding %c (%d)", expectedEncoding, expectedEncoding)
 }
 
 func TestEncode(t *testing.T)  {

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -6,29 +6,33 @@ import (
 	"testing"
 )
 
-func TestBase58RoundTrip(t *testing.T) {
+func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 16)
 	rand.Read(buf)
 
-	enc, err := Encode(Base58BTC, buf)
-	if err != nil {
-		t.Fatal(err)
+	baseList := []int{ Base16, Base32, Base32hex, Base58BTC, Base58Flickr, Base64, Base64url }
+
+	for _, base := range baseList {
+		enc, err := Encode(base, buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		e, out, err := Decode(enc)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if e != base {
+			t.Fatal("got wrong encoding out")
+		}
+
+		if !bytes.Equal(buf, out) {
+			t.Fatal("input wasnt the same as output", buf, out)
+		}
 	}
 
-	e, out, err := Decode(enc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if e != Base58BTC {
-		t.Fatal("got wrong encoding out")
-	}
-
-	if !bytes.Equal(buf, out) {
-		t.Fatal("input wasnt the same as output", buf, out)
-	}
-
-	_, _, err = Decode("")
+	_, _, err := Decode("")
 	if err == nil {
 		t.Fatal("shouldnt be able to decode empty string")
 	}

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -4,7 +4,47 @@ import (
 	"bytes"
 	"math/rand"
 	"testing"
+	"fmt"
+
+	"github.com/stretchr/testify/assert"
 )
+
+var sampleBytes = []byte("Decentralize everything!!")
+var encodedSamples = map[int]string{
+	Identity: string(0x00) + "Decentralize everything!!",
+	Base64pad: "MRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ==",
+}
+
+func testEncode(t *testing.T, encoding int, bytes []byte, expected string)  {
+	actual, err := Encode(encoding, bytes)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	assert.Equal(t, expected, actual, fmt.Sprintf("Encoding failure for encoding %c (%d)", encoding, encoding))
+}
+
+func testDecode(t *testing.T, expectedEncoding int, expectedBytes []byte, data string)  {
+	actualEncoding, actualBytes, err := Decode(data)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	assert.Equal(t, expectedEncoding, actualEncoding)
+	assert.Equal(t, expectedBytes, actualBytes, fmt.Sprintf("Encoding failure for encoding %c (%d)", expectedEncoding, expectedEncoding))
+}
+
+func TestEncode(t *testing.T)  {
+	for encoding, data := range encodedSamples {
+		testEncode(t, encoding, sampleBytes, data)
+	}
+}
+
+func TestDecode(t *testing.T)  {
+	for encoding, data := range encodedSamples {
+		testDecode(t, encoding, sampleBytes, data)
+	}
+}
 
 func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 17)

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestRoundTrip(t *testing.T) {
-	buf := make([]byte, 16)
+	buf := make([]byte, 17)
 	rand.Read(buf)
 
-	baseList := []int{ Base16, Base32, Base32hex, Base58BTC, Base58Flickr, Base64, Base64url }
+	baseList := []int{ Base16, Base32, Base32hex, Base58BTC, Base58Flickr, Base64, Base64url, Binary }
 
 	for _, base := range baseList {
 		enc, err := Encode(base, buf)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,12 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
+      "hash": "Qmb1DA2A9LS2wR4FFweB4uEDomFsdmnw1VLawLE1yQzudj",
+      "name": "base32",
+      "version": "0.0.0"
+    },
+    {
+      "author": "whyrusleeping",
       "hash": "QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf",
       "name": "go-base58",
       "version": "0.0.0"


### PR DESCRIPTION
This allows 8-bit clean channels to use unaltered binary data. For example you can use 'b' (8-bit binary) on the HTTP API, but 'y' (6-bit base64) on the command line to provide binary data as an argument.

This PR builds on top of #5 written by @mateon1