### PR TITLE
Use custom Base type

### DIFF
--- a/multibase.go
+++ b/multibase.go
@@ -1,13 +1,15 @@
 package multibase
 
 import (
-	"encoding/hex"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	b58 "github.com/jbenet/go-base58"
 	b32 "github.com/whyrusleeping/base32"
 )
+
+type Encoding int
 
 const (
 	Base1             = '1'
@@ -34,7 +36,7 @@ const (
 
 var ErrUnsupportedEncoding = fmt.Errorf("selected encoding not supported")
 
-func Encode(base int, data []byte) (string, error) {
+func Encode(base Encoding, data []byte) (string, error) {
 	switch base {
 	case Base16, Base16Upper:
 		return string(Base16) + hex.EncodeToString(data), nil
@@ -59,7 +61,7 @@ func Encode(base int, data []byte) (string, error) {
 	}
 }
 
-func Decode(data string) (int, []byte, error) {
+func Decode(data string) (Encoding, []byte, error) {
 	if len(data) == 0 {
 		return 0, nil, fmt.Errorf("cannot decode multibase for zero length string")
 	}
@@ -94,4 +96,3 @@ func Decode(data string) (int, []byte, error) {
 		return -1, nil, ErrUnsupportedEncoding
 	}
 }
-

--- a/multibase_test.go
+++ b/multibase_test.go
@@ -10,7 +10,7 @@ func TestRoundTrip(t *testing.T) {
 	buf := make([]byte, 16)
 	rand.Read(buf)
 
-	baseList := []int{ Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad }
+	baseList := []Encoding{Base16, Base32, Base32hex, Base32pad, Base32hexPad, Base58BTC, Base58Flickr, Base64pad, Base64urlPad}
 
 	for _, base := range baseList {
 		enc, err := Encode(base, buf)


### PR DESCRIPTION
Previously base variable were having type `int` which could be confusing
as with literal base number (16 for hex).

By using custom base variable I hope to make it more clear than it was
before.