### PR TITLE
Beef up tests before adding new codec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: deps
-	go test -race -v ./...
+	go test -count=1 -race -v ./...
 
 export IPFS_API ?= v04x.ipfs.io
 


### PR DESCRIPTION
This does not add a new codec, just beefs up the tests to look for permutations with a lot of leading zero bytes, and to wiggle the case on case-insensitive codecs