### PR TITLE
Test illustrating failure with a sole '2' as encoded string

### DIFF
--- a/multibase_test.go
+++ b/multibase_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"math/rand"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -108,6 +109,27 @@ func TestRoundTrip(t *testing.T) {
 		if err == nil {
 			t.Fatal(EncodingToStr[base] + " decode should fail on high-latin1")
 		}
+	}
+
+	for base := range EncodingToStr {
+
+		name := EncodingToStr[base]
+		if name == "base2" ||
+			strings.HasSuffix(name, "pad") ||
+			strings.HasSuffix(name, "padupper") {
+			continue
+		}
+
+		// try to roundtrip a lone '2'
+		encType, decodedBytes, err := Decode(string(base) + "2")
+		if err != nil {
+			t.Fatalf("%s decode of '2' failed: %s", EncodingToStr[base], err)
+		}
+		if encType != base {
+			t.Fatal("decoded wrong encoding")
+		}
+
+		testEncode(t, base, decodedBytes, string(base)+"2")
 	}
 
 	buf := make([]byte, 137+16) // sufficiently large prime number of bytes + another 16 to test leading 0s


### PR DESCRIPTION
I am not entirely sure what's going on here, so filing this as a PR
before I move on. Specfically the encodings specified as 'non-padding'
should not be having trouble here. Yet:
```
--- FAIL: TestRoundTrip (0.00s)
    multibase_test.go:55: encoding failed for b (98 / base32), expected: b2, got: b
    multibase_test.go:55: encoding failed for v (118 / base32hex), expected: v2, got: v
    multibase_test.go:126: base64 decode of '2' failed: illegal base64 data at input byte 0
```

Please do not close until we have investigated.