### PR TITLE
fix: add new emoji codepoint for Base256Emoji 🐉

### DIFF
--- a/base256emoji.go
+++ b/base256emoji.go
@@ -11,7 +11,8 @@ var base256emojiTable = [256]rune{
 	'🚀', '🪐', '☄', '🛰', '🌌', // Space
 	'🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘', // Moon
 	'🌍', '🌏', '🌎', // Our Home, for now (earth)
-	'☉', '☀', // Our Garden, for now (sol)
+	'🐉',                // Dragon!!!
+	'☀',                // Our Garden, for now (sol)
 	'💻', '🖥', '💾', '💿', // Computer
 	// The rest is completed from https://home.unicode.org/emoji/emoji-frequency/ at the time of creation (december 2021) (the data is from 2019), most used first until we reach 256.
 	// We exclude modifier based emojies (such as flags) as they are bigger than one single codepoint.

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.1.0"
+  "version": "v0.1.1"
 }


### PR DESCRIPTION
One of the values of base256emoji was not actually an emoji.

Here there be dragons instead !

See https://github.com/multiformats/go-multibase/commit/df5b7bc6ee807ace487c2d85cd8053d1c69e1108#r75683795 for context.

Blocked on: https://github.com/multiformats/multibase/pull/98