### PR TITLE
chore: release v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-multiformats-blue.svg?style=flat-square)](https://github.com/multiformats/multiformats)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](https://webchat.freenode.net/?channels=%23ipfs)
 [![](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-[![Travis CI](https://img.shields.io/travis/multiformats/go-multibase.svg?style=flat-square&branch=master)](https://travis-ci.org/multiformats/go-multibase)
+[![GoDoc](https://pkg.go.dev/badge/github.com/multiformats/go-multibase.svg)](https://pkg.go.dev/github.com/multiformats/go-multibase)
 [![codecov.io](https://img.shields.io/codecov/c/github/multiformats/go-multibase.svg?style=flat-square&branch=master)](https://codecov.io/github/multiformats/go-multibase?branch=master)
 
 > Implementation of [multibase](https://github.com/multiformats/multibase) -self identifying base encodings- in Go.

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.2.0"
+  "version": "v0.3.0"
 }


### PR DESCRIPTION
- version.json: bump v0.2.0 → v0.3.0
- README.md: remove defunct freenode and Travis CI badges, add GoDoc

## Tests

- [x] smoke-test in https://github.com/ipfs/kubo/pull/11274